### PR TITLE
Correct some tests before merging massive refactor

### DIFF
--- a/src/poliastro/tests/tests_twobody/test_perturbations.py
+++ b/src/poliastro/tests/tests_twobody/test_perturbations.py
@@ -462,7 +462,7 @@ def normalize_to_Curtis(t0, sun_r):
     return 149600000 * r / norm(r)
 
 
-# @pytest.mark.slow
+@pytest.mark.slow
 def test_solar_pressure():
     # based on example 12.9 from Howard Curtis
     with solar_system_ephemeris.set("builtin"):


### PR DESCRIPTION
This pull requests removes a commented decorator and makes use of units in `test_atmospheric_drag` as suggested by the code review in [#763](https://github.com/poliastro/poliastro/pull/763).

However, I was not able to reproduce the error in the doctest :confused: 